### PR TITLE
fail CI on any shellcheck warning or error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -171,9 +171,8 @@ runs:
         OUTPUT: ${{ steps.check.outputs.output }}
       run: |
         # Check Summary
-        cat >$"GITHUB_STEP_SUMMARY"<<EOF
-        "$OUTPUT"
-        EOF
+        echo "$OUTPUT" >>$"GITHUB_STEP_SUMMARY"
+        # check failed, stop the job
         exit 1
 
     - name: DNSControl
@@ -216,9 +215,9 @@ runs:
       # execute if user set post_pr_comment, this is a PR event, AND dnscontrol job ran
       if: ${{ inputs.post_pr_comment && github.event.pull_request.number != '' && steps.dnscontrol.outcome != 'skipped' }}
       with:
-        comment-tag: dnscontrol_preview_push_external
+        comment-tag: dnscontrol_composite_action
         message: |
-          <details open><summary>Results</summary>
+          <details open><summary>DNSControl Results</summary>
 
           ### DNSControl Results
 
@@ -236,6 +235,4 @@ runs:
         OUTPUT: ${{ steps.dnscontrol.outputs.output }}
       run: |
         # Job Summary
-        cat >"$GITHUB_STEP_SUMMARY"<<EOF
-        "$OUTPUT"
-        EOF
+        echo "$OUTPUT" >>"$GITHUB_STEP_SUMMARY"

--- a/bin/shellcheck.sh
+++ b/bin/shellcheck.sh
@@ -1,33 +1,59 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -eo pipefail
 
 # extract each bash `run` step from action and all workflows and run them through `bash -n` for
 # validity and shellcheck for safety. requires `yq` and `shellcheck` in $PATH
 
+FAILS=0
 IFS="
 "
 
-find action.yml .github/workflows -type f -name \*yml -print -o -name \*yaml -print \
-  | while read -ra YAMLFILE
-    do
+# Create an array of YAML files (recent bash and zsh supported here)
+if [[ -n "$BASH_VERSION" ]]; then
+  YAMLFILES=()
+  while read -r YAMLFILE; do
+      YAMLFILES+=("$YAMLFILE")
+  done < <(find action.yml .github/workflows -type f -name \*yml -print -o -name \*yaml -print)
+else
+  if [[ -n "$ZSH_VERSION" ]]; then
+    YAMLFILES=("${(@f)$(find action.yml .github/workflows -type f -name \*yml -print -o -name \*yaml -print)}")
+  else
+    echo "This script requires a recent bash or zsh shell"
+    exit 1
+  fi
+fi
 
-      echo "Checking $YAMLFILE"
 
-      for n in $(yq '.. | select(has("steps")) | .steps[] | select(.run != null) | .name' < $YAMLFILE)
-      do
-        # do not error out while in this inner loop: we want to find all problems
-        set +e
+for YAMLFILE in "${YAMLFILES[@]}"; do
 
-        # prepare a safe location to create a temporary script for evaluation
-        tmpscript=$(mktemp)
+  echo "Checking $YAMLFILE"
 
-        # extract the jobs.*.steps[].run element into the temp file
-        yq ".. | select(has(\"steps\")) | .steps[] | select(.name == \"$n\") | .run" < "$YAMLFILE" > "$tmpscript"
+  for n in $(yq '.. | select(has("steps")) | .steps[] | select(.run != null) | .name' < $YAMLFILE)
+  do
+    # do not error out while in this inner loop: we want to find all problems
+    set +e
 
-        # run the checks
-        bash -n "$tmpscript" || echo "the script in $n did not pass the validity check"
-        shellcheck --shell bash -S warning "$tmpscript" || echo "the script in $n did not pass shellcheck"
+    # prepare a safe location to create a temporary script for evaluation
+    tmpscript=$(mktemp)
 
-        rm "$tmpscript"
-        set -e
-      done
-    done
+    # extract the jobs.*.steps[].run element into the temp file
+    yq ".. | select(has(\"steps\")) | .steps[] | select(.name == \"$n\") | .run" < "$YAMLFILE" > "$tmpscript"
+
+    # run the checks
+    shellcheck --shell bash -S warning "$tmpscript"
+    if [ $? -ne 0 ]; then
+      echo ""
+      echo "The script in $n in $YAMLFILE did not pass shellcheck"
+      echo ""
+      ((FAILS++))
+    fi
+    rm "$tmpscript"
+    set -e
+  done
+done
+
+if [[ $FAILS -ne 0 ]]; then
+  echo "$FAILS error(s) or warning(s) detected, please fix and run bin/shellcheck.sh again"
+  exit 1
+fi


### PR DESCRIPTION
This changes the shellcheck wrapper to exit 1 on any finding from shellcheck at or above warning.

* tidy action.yml to remove extra quotes on summary output